### PR TITLE
mavenlink 4 1 3 lock rails6 0

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.add_dependency "activerecord", "~> 6.1.4"
+  spec.add_dependency "activerecord", "~> 6.0.0"
   spec.add_dependency "delayed_job"
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"
@@ -12,5 +12,5 @@ Gem::Specification.new do |spec|
   spec.name           = "delayed_job_active_record"
   spec.require_paths  = ["lib"]
   spec.summary        = "ActiveRecord backend for DelayedJob"
-  spec.version        = "4.1.10"
+  spec.version        = "4.1.11"
 end


### PR DESCRIPTION
- Possible perf improvement to delayed job event loop
- oops
- Fix bug in reserve_with_scope_using_default_sql
- fix the error with the array returned
- accidentally committed pry
- Added racerpeter and redis setting
- Oops -- forgot require
- Make specs work
- to fix specs
- allow redlock to be lazy loaded and use global config
- add alternate strategy
- this is required to be like this
- only do alt redis strategy
- to properly setup and spec the selection of the redis sql finder strategy
- Increase lock timeout to 10s
- side step the module name
- use the class name directly to prevent other loading issues
- this is a simpler way to rename
- Allow Delayed::Backend::ActiveRecord::Configuration to accept mavenlink specific sql strategy options
- Use exclude to validate provided query optimization strategy
- Add missing specs for reserve_with_scope strategy methods for various connection adapters
- Remove unnecessary spec
- Comment out minimum coverage
- relax activerecord version requirements for rails6x support
- more version upgrades
- Relax activerecord to 6.0
